### PR TITLE
Cleanup Bindings

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -228,24 +228,24 @@ jobs:
       - name: Install wheel
         run: python -m pip install --find-links dist tree-sitter-jinja2
 
-  publish:
-    needs: [test-wheels, test-sdist]
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
-      - name: Fetch dists from cache
-        uses: actions/download-artifact@v2
-      - name: Gather dists
-        run: |
-          mkdir dist/
-          find . -type f \( -name '*.whl' -o -name '*.tar.gz' \) -exec mv -i '{}' ./dist/ ';'
-      - name: Show all dists
-        run: ls -lh dist
-      - run: python -m pip install twine
-      - name: Publish distribution 📦 to Test PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
-        run: python -m twine check dist/* && python -m twine upload --repository-url https://test.pypi.org/legacy/ --non-interactive dist/* --verbose
+  # publish:
+  #   needs: [test-wheels, test-sdist]
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/setup-python@v2
+  #       with:
+  #         python-version: "3.9"
+  #     - name: Fetch dists from cache
+  #       uses: actions/download-artifact@v2
+  #     - name: Gather dists
+  #       run: |
+  #         mkdir dist/
+  #         find . -type f \( -name '*.whl' -o -name '*.tar.gz' \) -exec mv -i '{}' ./dist/ ';'
+  #     - name: Show all dists
+  #       run: ls -lh dist
+  #     - run: python -m pip install twine
+  #     - name: Publish distribution 📦 to Test PyPI
+  #       env:
+  #         TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+  #         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+  #       run: python -m twine check dist/* && python -m twine upload --repository-url https://test.pypi.org/legacy/ --non-interactive dist/* --verbose

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ prebindings: build
 bindings: prebindings
 	$(L)cd bindings$(PATHSEP)python $(CMDSEP) python -m build --wheel
 
-# runs the tree-sitter unit tests and python unit tests
+# runs the tree-sitter unit tests
 .PHONY: test
 test: build
 	$(L)npx tree-sitter test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # tree-sitter-jinja2
 This Jinja2 grammar for tree-sitter is currently incomplete.
 
+# demo
+To run the built-in tree-sitter demo for this grammar:
+
+- make sure the docker daemon is running
+- run `make demo`
+
 ## Future Work
 - Add missing jinja2 syntax
 - Add Rust bindings to CI & add badge to bindings/rust/README.md

--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 This Jinja2 grammar for tree-sitter is currently incomplete.
 
 ## Future Work
-- Add CI & badge
-- Test or remove Node bindings
+- Add missing jinja2 syntax
+- Add Rust bindings to CI & add badge to bindings/rust/README.md
+- Test Node bindings

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/fishtown-analytics/tree-sitter-jinja2/actions/workflows/build_python/badge.svg)
+![](https://github.com/fishtown-analytics/tree-sitter-jinja2/actions/workflows/build_wheels.yml/badge.svg)
 # Bindings for Python
 
 ## To use the bindings in your project:

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,3 +1,4 @@
+![](https://github.com/fishtown-analytics/tree-sitter-jinja2/actions/workflows/build_python/badge.svg)
 # Bindings for Python
 
 ## To use the bindings in your project:

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,4 +1,5 @@
 ![](https://github.com/fishtown-analytics/tree-sitter-jinja2/actions/workflows/build_wheels.yml/badge.svg)
+![](https://pypip.in/v/tree-sitter-jinja2/badge.svg)
 # Bindings for Python
 
 ## To use the bindings in your project:
@@ -6,7 +7,7 @@
 `requirements.txt`:
 ```
 tree-sitter==0.19.0
-tree-sitter-jinja2
+tree-sitter-jinja2==0.1.0a1
 ```
 
 ```python

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,8 +1,9 @@
 # Bindings for Python
 
 ## To use the bindings in your project:
+
+`requirements.txt`:
 ```
-# requirements.txt
 tree-sitter==0.19.0
 tree-sitter-jinja2
 ```

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,0 +1,17 @@
+# Bindings for Rust
+
+## To use the bindings in your project:
+
+`Cargo.toml`:
+```
+[dependencies]
+tree-sitter = "0.19"
+tree-sitter-jinja2 = { git = "ssh://git@github.com/fishtown-analytics/tree-sitter-jinja2", branch =" main" }
+```
+
+```rust
+let code = r#"This text supports {{ 'jinja' }}."#;
+let mut parser = tree_sitter::Parser::new();
+parser.set_language(tree_sitter_jinja2::language()).expect("Error loading jinja2 grammar");
+let tree = parser.parse(code, None);
+```


### PR DESCRIPTION
In preparation for opening up the repo I wanted to add some docs to the bindings and comment out the GA step for publishing the python bindings. Right now the publish step fails on every PR where you don't bump the version to an unused one which is not great for making changes to non-distributed code like documentation.